### PR TITLE
fix: Signavio Process Editor was listed twice in tools json

### DIFF
--- a/tools-tested-by-miwg.json
+++ b/tools-tested-by-miwg.json
@@ -374,22 +374,6 @@
       "notes": ""
     },
     {
-      "vendor": "Signavio GmbH",
-      "tool": "Signavio Process Editor",
-      "maintainer": "",
-      "version": "10.0.0",
-      "website": "http://www.signavio.com",
-      "bpiId": "",
-      "supportsBpmn2": true,
-      "hasImport": true,
-      "hasExport": true,
-      "hasRoundtrip": true,
-      "lastResultsSubmitted": "2016",
-      "participatedInDemosByYear": "2016,2015,2014,2013",
-      "openSource": false,
-      "notes": ""
-    },
-    {
       "vendor": "Sparx",
       "tool": "Enterprise Architect",
       "maintainer": "",


### PR DESCRIPTION
Also in the table result Signavio Process Editor is displayed twice due to his entry duplication in tools-tested-by-miwg.json , this should fix .