### PR TITLE
README: align C.7.0 description in 'Verified Reference Models'

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,7 +337,7 @@ _Process with data input/outputs and event sub-process from 2019 Demo in Amsterd
 
 
 ### C.7.0
-_Process with senquence flow on sequence flow from 2020 Demo in Orlando_
+_Process with data inputs and data object connected to sequence flow from 2020 Virtual Demo_
 
 ![](Reference/C.7.0.png)
 


### PR DESCRIPTION
It is now aligned with the content of `test-case-structure.json` to
match what is displayed on the results website.
This also fixes typos of the previous description.