### PR TITLE
Fix demo participation

### DIFF
--- a/tools-tested-by-miwg.json
+++ b/tools-tested-by-miwg.json
@@ -561,7 +561,7 @@
       "hasExport": true,
       "hasRoundtrip": true,
       "lastResultsSubmitted": "2022",
-      "participatedInDemosByYear": "2022",
+      "participatedInDemosByYear": "2022,2020",
       "openSource": false,
       "notes": ""
     },


### PR DESCRIPTION
The latest merged PR contained a minor error as it no longer contained the viadee demo participation in 2020. This is fixed in this trivial change.